### PR TITLE
Upgrade Headless UI to v2.2 and fix scroll-lock issue on Programs dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@headlessui/react": "^1.7.19",
+        "@headlessui/react": "^2.2.1",
         "@next/third-parties": "^15.0.3",
         "@sendgrid/mail": "^8.1.4",
         "@tabler/icons-react": "^3.21.0",
@@ -369,21 +369,76 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@headlessui/react": {
-      "version": "1.7.19",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
-      "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-virtual": "^3.0.0-beta.60",
-        "client-only": "^0.0.1"
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.1.tgz",
+      "integrity": "sha512-daiUqVLae8CKVjEVT19P/izW0aGK0GNhMSAeMlrDebKmoVZHcRRwbxzgtnEadUVDXyBsWo9/UH4KHeniO+0tMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@tanstack/react-virtual": "^3.11.1"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1082,6 +1137,103 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.2.tgz",
+      "integrity": "sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
+      "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/flags": "^3.1.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-stately/flags": "^3.1.1",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.1.tgz",
+      "integrity": "sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -6248,6 +6400,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postbuild": "next-sitemap"
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.19",
+    "@headlessui/react": "^2.2.1",
     "@next/third-parties": "^15.0.3",
     "@sendgrid/mail": "^8.1.4",
     "@tabler/icons-react": "^3.21.0",

--- a/src/components/Faqs.js
+++ b/src/components/Faqs.js
@@ -3,20 +3,23 @@
 import bulb from '/public/images/illustrations/bulb.svg'
 import questionMark from '/public/images/illustrations/question-mark.svg'
 import { Icon } from '@/components/Icon'
-import { Disclosure, Transition } from '@headlessui/react'
-import clsx from 'clsx'
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel
+} from '@headlessui/react'
 import Image from 'next/image'
 import Link from 'next/link'
 
 export const Faqs = ({ faqs }) => {
   return (
-    <section className="bg-yellow-100 py-20 sm:py-28" id="faq">
+    <section className="py-20 bg-yellow-100 sm:py-28" id="faq">
       {/* Container */}
       <div className="mx-auto px-4 sm:px-6 lg:max-w-(--breakpoint-lg) lg:px-8">
         {/* Section header title and subtext  */}
         <div className="max-w-2xl">
-          <h2 className="h2 text-purple-900">Frequently asked questions</h2>
-          <p className="mt-4 max-w-2xl text-xl leading-relaxed text-purple-800 lg:text-left">
+          <h2 className="text-purple-900 h2">Frequently asked questions</h2>
+          <p className="max-w-2xl mt-4 text-xl leading-relaxed text-purple-800 lg:text-left">
             If you have additional questions please{' '}
             <Link href="/contact" className="underline">
               contact us
@@ -29,12 +32,12 @@ export const Faqs = ({ faqs }) => {
           {/* Decorator images*/}
           <div>
             <Image
-              className="absolute -left-60 top-10 hidden h-auto w-28 2xl:block"
+              className="absolute hidden h-auto -left-60 top-10 w-28 2xl:block"
               src={questionMark}
               alt=""
             />
             <Image
-              className="absolute -right-60 bottom-10 hidden h-auto w-28 2xl:block"
+              className="absolute hidden h-auto -right-60 bottom-10 w-28 2xl:block"
               src={bulb}
               alt=""
             />
@@ -43,37 +46,25 @@ export const Faqs = ({ faqs }) => {
             <Disclosure
               key={index}
               as="li"
-              className="w-full rounded-3xl bg-white px-5 py-6 sm:px-12 sm:py-8"
+              className="w-full px-5 py-6 bg-white rounded-3xl sm:px-12 sm:py-8"
             >
-              {({ open }) => (
-                <>
-                  <Disclosure.Button className="group flex w-full items-center justify-between text-lg sm:text-xl">
-                    <span className="text-left font-medium text-purple-900 duration-300 ease-in-out group-hover:text-purple-600">
-                      {faq.data.question}
-                    </span>
-                    <Icon
-                      icon="chevronDown"
-                      className={clsx(
-                        open && 'rotate-180',
-                        'ml-3 h-6 w-6 shrink-0 text-purple-700 duration-300 ease-in-out group-hover:text-purple-600 sm:ml-6'
-                      )}
-                      stroke={2}
-                    />
-                  </Disclosure.Button>
-                  <Transition
-                    enter="transition duration-100 ease-out"
-                    enterFrom="transform scale-95 opacity-0"
-                    enterTo="transform scale-100 opacity-100"
-                    leave="transition duration-75 ease-out"
-                    leaveFrom="transform scale-100 opacity-100"
-                    leaveTo="transform scale-95 opacity-0"
-                  >
-                    <Disclosure.Panel className="mt-3 text-base leading-relaxed text-purple-800 sm:text-lg">
-                      {faq.data.answer}
-                    </Disclosure.Panel>
-                  </Transition>
-                </>
-              )}
+              <DisclosureButton className="flex items-center justify-between w-full text-lg cursor-pointer group sm:text-xl">
+                <span className="font-medium text-left text-purple-900 duration-300 ease-in-out group-hover:text-purple-600">
+                  {faq.data.question}
+                </span>
+                <Icon
+                  icon="chevronDown"
+                  className="ml-3 h-6 w-6 flex-shrink-0 text-purple-700 duration-300 ease-in-out group-hover:text-purple-600 group-data-[open]:rotate-180 sm:ml-6"
+                  stroke={2}
+                />
+              </DisclosureButton>
+
+              <DisclosurePanel
+                transition
+                className="mt-3 text-base leading-relaxed text-purple-800 data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-100 data-[leave]:duration-75 data-[enter]:ease-out data-[leave]:ease-in sm:text-lg"
+              >
+                {faq.data.answer}
+              </DisclosurePanel>
             </Disclosure>
           ))}
         </ul>

--- a/src/components/HomeHero.js
+++ b/src/components/HomeHero.js
@@ -47,7 +47,7 @@ export const HomeHero = () => {
   }
 
   return (
-    <section className="bg-linear-to-b from-purple-25 to-purple-50 px-4 pt-16 sm:px-6 lg:px-8">
+    <section className="px-4 pt-16 bg-linear-to-b from-purple-25 to-purple-50 sm:px-6 lg:px-8">
       {/* Hero container */}
       <div
         className="mx-auto max-w-(--breakpoint-xl) lg:grid lg:grid-cols-12 lg:gap-8"
@@ -56,21 +56,21 @@ export const HomeHero = () => {
         {/* Hero text content */}
         <div className="flex flex-col items-center justify-center lg:col-span-6 lg:items-start">
           <div className="block">
-            <span className="inline-block rounded-full bg-purple-200 px-4 py-2 font-medium text-purple-700 shadow-md">
+            <span className="inline-block px-4 py-2 font-medium text-purple-700 bg-purple-200 rounded-full shadow-md">
               Registration fees waived through 2025!
             </span>
           </div>
-          <h1 className="h1 mt-4 max-w-xl text-center text-purple-900 sm:mt-5 lg:max-w-none lg:text-left">
+          <h1 className="max-w-xl mt-4 text-center text-purple-900 h1 sm:mt-5 lg:max-w-none lg:text-left">
             Welcome to Texas Twisters Gymnastics!
           </h1>
-          <p className="mt-3 max-w-2xl text-center text-xl leading-loose text-purple-800 lg:text-left">
+          <p className="max-w-2xl mt-3 text-xl leading-loose text-center text-purple-800 lg:text-left">
             Located in the heart of Georgetown, TX, our programs are designed to
             challenge and inspire athletes of all ages. From beginner to
             advanced, we're excited to provide you a safe, fun, and supportive
             environment throughout your gymnastics journey.
           </p>
           {/* Hero buttons */}
-          <div className="mt-8 flex flex-col items-center overflow-hidden sm:flex-row">
+          <div className="flex flex-col items-center mt-8 overflow-hidden sm:flex-row">
             <Button
               onClick={() => {
                 track(EVENT_NAMES.BUTTON_CLICK, {
@@ -83,7 +83,7 @@ export const HomeHero = () => {
               Enroll today
               <Icon
                 icon="arrowNarrowRight"
-                className="ml-3 h-6 w-6 group-hover:animate-horizontal-bounce"
+                className="w-6 h-6 ml-3 group-hover:animate-horizontal-bounce"
                 stroke={2}
               />
             </Button>
@@ -143,77 +143,61 @@ export const HomeHero = () => {
           </div>
         </div>
         {/* Hero image & video */}
-        <div className="mx-auto mt-16 flex max-w-3xl flex-col justify-center lg:col-span-6 lg:mt-0 lg:max-w-none">
+        <div className="flex flex-col justify-center max-w-3xl mx-auto mt-16 lg:col-span-6 lg:mt-0 lg:max-w-none">
           <div className="relative">
             <Image
               src={heroImage}
               priority
-              className="h-auto w-full"
+              className="w-full h-auto"
               alt="A picture collage of children doing gymnastics at Texas Twisters Gymnastics"
               sizes="(min-width: 1280px) 39rem, (min-width: 1024px) 50vw, (min-width: 768px) 48rem, 100vw"
             />
-            {/*<div className="absolute inset-0 flex items-center justify-center">*/}
-            {/*    <span className="absolute inline-flex w-20 h-20 bg-purple-400/60 rounded-fu animate-ping" />*/}
-            {/*    /!* Video modal button *!/*/}
-            {/*    <button*/}
-            {/*        className="relative z-10 flex items-center justify-center w-20 h-20 duration-300 ease-in-out rounded-full outline-hidden bg-purple-600/90 group hover:bg-purple-600/95"*/}
-            {/*        onClick={() => openModal()}*/}
-            {/*    >*/}
-            {/*        <Icon*/}
-            {/*            icon="playFilled"*/}
-            {/*            className="w-12 h-12 duration-300 ease-in-out text-white/90 group-hover:text-white/95"*/}
-            {/*        />*/}
-            {/*    </button>*/}
-            {/*</div>*/}
+            {/* <div className="absolute inset-0 flex items-center justify-center">
+              <span className="absolute inline-flex w-20 h-20 bg-purple-400 rounded-full animate-ping opacity-60" />
+              {/* Video modal button */}
+            {/* <button
+                className="relative z-10 flex items-center justify-center w-20 h-20 duration-300 ease-in-out rounded-full outline-none group bg-purple-600/90 hover:bg-purple-600/95"
+                onClick={() => openModal()}
+              >
+                <Icon
+                  icon="playFilled"
+                  className="w-12 h-12 duration-300 ease-in-out text-white/90 group-hover:text-white/95"
+                />
+              </button>
+            </div> */}
           </div>
         </div>
         {/* Video modal*/}
-        {/*<Transition appear show={isOpen} as={Fragment}>*/}
-        {/*    <Dialog*/}
-        {/*        as="div"*/}
-        {/*        className="fixed inset-0 z-10 w-full h-full px-4 overflow-hidden transition duration-150 ease-linear"*/}
-        {/*        aria-modal="true"*/}
-        {/*        onClose={closeModal}*/}
-        {/*    >*/}
-        {/*        /!* Modal overlay *!/*/}
-        {/*        <Transition.Child*/}
-        {/*            as={Fragment}*/}
-        {/*            enter="transition ease-out duration-300"*/}
-        {/*            enterFrom="opacity-0"*/}
-        {/*            enterTo="opacity-50"*/}
-        {/*            leave="transition ease-in duration-200"*/}
-        {/*            leaveFrom="opacity-50"*/}
-        {/*            leaveTo="opacity-0"*/}
-        {/*        >*/}
-        {/*            <Dialog.Overlay className="fixed inset-0 w-screen h-screen transition-opacity duration-300 ease-linear bg-black opacity-50" />*/}
-        {/*        </Transition.Child>*/}
-        {/*        <div className="flex items-center justify-center w-auto min-h-screen mx-auto">*/}
-        {/*            /!* Modal Content *!/*/}
-        {/*            <Transition.Child*/}
-        {/*                as={Fragment}*/}
-        {/*                enter="transition ease-out duration-300"*/}
-        {/*                enterFrom="opacity-0 scale-95 translate-y-24"*/}
-        {/*                enterTo="opacity-100 scale-100 translate-y-0"*/}
-        {/*                leave="transition ease-out duration-200"*/}
-        {/*                leaveFrom="opacity-100 scale-100 translate-y-0"*/}
-        {/*                leaveTo="opacity-0 scale-95 translate-y-24"*/}
-        {/*            >*/}
-        {/*                <Dialog.Panel className="w-full max-w-6xl max-h-full overflow-auto bg-white rounded-2xl">*/}
-        {/*                    <div className="relative aspect-w-16 aspect-h-9">*/}
-        {/*                        <iframe*/}
-        {/*                            className="absolute w-full h-full"*/}
-        {/*                            src="https://www.youtube.com/embed/2ly2il11JaU"*/}
-        {/*                            title="Video"*/}
-        {/*                            webkitallowfullscreen*/}
-        {/*                            mozallowfullscreen*/}
-        {/*                            allowFullScreen*/}
-        {/*                        />*/}
-        {/*                    </div>*/}
-        {/*                </Dialog.Panel>*/}
-        {/*            </Transition.Child>*/}
-        {/*        </div>*/}
-        {/*    </Dialog>*/}
-        {/*</Transition>*/}
+        {/* <Dialog
+          as="div"
+          className="fixed inset-0 z-10 w-full h-full px-4 overflow-hidden transition duration-150 ease-linear"
+          aria-modal="true"
+          open={isOpen}
+          onClose={closeModal}
+        >
+          <DialogBackdrop
+            transition
+            className="fixed inset-0 h-screen w-screen bg-black opacity-50 transition-opacity data-[closed]:opacity-0 data-[open]:opacity-50 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in"
+          />
+          <div className="flex items-center justify-center w-auto min-h-screen mx-auto">
+            <DialogPanel
+              transition
+              className="max-h-full w-full max-w-6xl transform overflow-auto rounded-2xl bg-white transition data-[closed]:translate-y-24 data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in"
+            >
+              <div className="relative aspect-h-9 aspect-w-16">
+                <iframe
+                  className="absolute w-full h-full"
+                  allow="autoplay"
+                  src="https://www.youtube.com/embed/oRcNS5CCbnc?autoplay=1"
+                  title="Video"
+                  webkitallowfullscreen
+                  mozallowfullscreen
+                  allowFullScreen
+                />
+              </div>
+            </DialogPanel>
+          </div>
+        </Dialog> */}
       </div>
       {/*Visible only on sm screens ( <= 640px ) and lg screens ( >= 1024px	< 1280px ) */}
       <div className="flex flex-col items-center mt-20 lg:mt-24 sm:hidden lg:flex xl:hidden">

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -4,7 +4,15 @@ import logo from '/public/images/logo.png'
 import { Button } from '@/components/Button'
 import { Icon } from '@/components/Icon'
 import { EVENT_IDS, EVENT_NAMES } from '@/utils/tracking'
-import { Menu, Popover, Transition } from '@headlessui/react'
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  Popover,
+  PopoverButton,
+  PopoverPanel
+} from '@headlessui/react'
 import { track } from '@vercel/analytics'
 import clsx from 'clsx'
 import Image from 'next/image'
@@ -25,42 +33,17 @@ const navigation = [
 export function Navbar({ programs }) {
   const pathname = usePathname()
 
-  function MenuIcon({ open }) {
+  function Hamburger() {
     return (
-      <>
-        <span
-          className={clsx(
-            'absolute block h-1 rotate-0 transform rounded-full opacity-100 transition-all duration-300 ease-in-out',
-            open
-              ? 'left-1/2 top-2 w-0 bg-purple-50 group-hover:bg-white'
-              : 'left-0 top-0 w-full bg-purple-900 group-hover:bg-purple-600'
-          )}
-        />
-        <span
-          className={clsx(
-            'absolute left-0 top-2 block h-1 w-full transform rounded-full opacity-100 transition-all duration-300 ease-in-out group-hover:bg-purple-600',
-            open
-              ? 'rotate-45 bg-purple-50 group-hover:bg-white'
-              : 'rotate-0 bg-purple-900 group-hover:bg-purple-600'
-          )}
-        />
-        <span
-          className={clsx(
-            'absolute left-0 top-2 block h-1 w-full transform rounded-full opacity-100 transition-all duration-300 ease-in-out group-hover:bg-purple-600',
-            open
-              ? '-rotate-45 bg-purple-50 group-hover:bg-white'
-              : 'rotate-0 bg-purple-900 group-hover:bg-purple-600'
-          )}
-        />
-        <span
-          className={clsx(
-            'absolute block h-1 rotate-0 transform rounded-full opacity-100 transition-all duration-300 ease-in-out group-hover:bg-purple-600',
-            open
-              ? 'left-1/2 top-2 w-0 bg-purple-50 group-hover:bg-white'
-              : 'left-0 top-4 w-full bg-purple-900 group-hover:bg-purple-600'
-          )}
-        />
-      </>
+      <PopoverButton
+        className="relative z-50 w-6 h-5 transition duration-500 ease-in-out transform rotate-0 cursor-pointer group focus:outline-none"
+        aria-label="Toggle Navigation"
+      >
+        <span className="absolute left-0 top-0 block h-1 w-full rotate-0 transform rounded-full bg-purple-900 opacity-100 transition-all duration-300 ease-in-out group-hover:bg-purple-600 group-data-[open]:left-1/2 group-data-[open]:top-2 group-data-[open]:w-0 group-data-[open]:bg-purple-50 group-data-[open]:group-hover:bg-white" />
+        <span className="absolute left-0 top-2 block h-1 w-full transform rounded-full bg-purple-900 opacity-100 transition-all duration-300 ease-in-out group-hover:bg-purple-600 group-data-[open]:rotate-45 group-data-[open]:bg-purple-50 group-data-[open]:group-hover:bg-white" />
+        <span className="absolute left-0 top-2 block h-1 w-full transform rounded-full bg-purple-900 opacity-100 transition-all duration-300 ease-in-out group-hover:bg-purple-600 group-data-[open]:-rotate-45 group-data-[open]:bg-purple-50 group-data-[open]:group-hover:bg-white" />
+        <span className="absolute left-0 top-4 block h-1 w-full rotate-0 transform rounded-full bg-purple-900 opacity-100 transition-all duration-300 ease-in-out group-hover:bg-purple-600 group-data-[open]:left-1/2 group-data-[open]:top-2 group-data-[open]:w-0 group-data-[open]:bg-purple-50 group-data-[open]:group-hover:bg-white" />
+      </PopoverButton>
     )
   }
 
@@ -68,85 +51,69 @@ export function Navbar({ programs }) {
     return (
       <div className="block lg:hidden">
         <Popover>
-          <Popover.Button
-            className="group relative z-50 h-5 w-6 rotate-0 transform cursor-pointer transition duration-500 ease-in-out focus:outline-hidden"
-            aria-label="Toggle Navigation"
+          <Hamburger />
+
+          <PopoverPanel
+            as="div"
+            transition
+            className="absolute inset-x-0 top-0 z-40 w-screen transform overflow-y-scroll bg-gradient-to-tr from-purple-600 to-purple-600 px-4 py-16 transition data-[closed]:-translate-y-full data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in sm:px-8"
           >
-            {({ open }) => <MenuIcon open={open} />}
-          </Popover.Button>
-
-          <Transition
-            as={Fragment}
-            enter="duration-300 ease-out"
-            enterFrom="opacity-0 -translate-y-full"
-            enterTo="opacity-100 translate-y-0"
-            leave="duration-200 ease-in"
-            leaveFrom="opacity-100 translate-y-0"
-            leaveTo="opacity-0 -translate-y-full"
-          >
-            <Popover.Panel
-              as="div"
-              className="absolute inset-x-0 top-0 z-40 w-screen overflow-y-scroll bg-linear-to-tr from-purple-600 to-purple-600 px-4 py-16 sm:px-8"
-            >
-              <div className="flex h-full w-full flex-col items-center justify-center">
-                <div className="mx-auto flex w-full flex-col items-center justify-evenly space-y-6">
-                  {navigation.map(link => (
-                    <Fragment key={`mobile-link-${link.label}`}>
-                      {link.label !== 'Programs' && (
-                        <Link href={link.href}>
-                          <div className="group relative p-0.5">
-                            <span className="relative z-10 text-2xl font-medium text-purple-50 duration-300 ease-in-out group-hover:text-white">
-                              {link.label}
-                            </span>
-                            <span className="absolute -left-1 -right-1 bottom-0 h-1.5 origin-bottom scale-x-0 transform rounded-lg bg-yellow-400 duration-300 ease-in-out group-hover:scale-x-100" />
-                          </div>
-                        </Link>
-                      )}
-                    </Fragment>
-                  ))}
-
-                  <Link
-                    onClick={() => {
-                      track(EVENT_NAMES.LINK_CLICK, {
-                        id: EVENT_IDS.CUSTOMER_PORTAL,
-                        path: window.location.pathname
-                      })
-                    }}
-                    href="https://portal.iclasspro.com/texastwisters/dashboard"
-                    target="_blank"
-                  >
-                    <Button>Customer Portal</Button>
-                  </Link>
-                </div>
-
-                <hr className="my-8 w-full border-purple-200/30 sm:my-10" />
-
-                <div className="mx-auto w-full max-w-md">
-                  <p className="text-center text-lg font-semibold uppercase tracking-wider text-purple-200 sm:text-left">
-                    Programs
-                  </p>
-                  <div className="mt-4 grid justify-items-center gap-4 sm:grid-cols-2 sm:justify-items-start sm:gap-x-8">
-                    {programs.map((program, index) => (
-                      <Link
-                        href={`/programs/${program.slug}`}
-                        key={`mobile-dropdown-${program.data.name}`}
-                        className={clsx(
-                          index % 2 == 1 && 'sm:justify-self-end'
-                        )}
-                      >
+            <div className="flex flex-col items-center justify-center w-full h-full">
+              <div className="flex flex-col items-center w-full mx-auto space-y-6 justify-evenly">
+                {navigation.map(link => (
+                  <Fragment key={`mobile-link-${link.label}`}>
+                    {link.label !== 'Programs' && (
+                      <Link href={link.href}>
                         <div className="group relative p-0.5">
-                          <span className="relative z-10 text-xl font-medium text-purple-50 duration-300 ease-in-out group-hover:text-white">
-                            {program.data.name}
+                          <span className="relative z-10 text-2xl font-medium duration-300 ease-in-out text-purple-50 group-hover:text-white">
+                            {link.label}
                           </span>
                           <span className="absolute -left-1 -right-1 bottom-0 h-1.5 origin-bottom scale-x-0 transform rounded-lg bg-yellow-400 duration-300 ease-in-out group-hover:scale-x-100" />
                         </div>
                       </Link>
-                    ))}
-                  </div>
+                    )}
+                  </Fragment>
+                ))}
+
+                <Link
+                  onClick={() => {
+                    track(EVENT_NAMES.LINK_CLICK, {
+                      id: EVENT_IDS.CUSTOMER_PORTAL,
+                      path: window.location.pathname
+                    })
+                  }}
+                  href="https://portal.iclasspro.com/texastwisters/dashboard"
+                  target="_blank"
+                >
+                  <Button>Customer Portal</Button>
+                </Link>
+              </div>
+
+              <hr className="w-full my-8 border-purple-200/30 sm:my-10" />
+
+              <div className="w-full max-w-md mx-auto">
+                <p className="text-lg font-semibold tracking-wider text-center text-purple-200 uppercase sm:text-left">
+                  Programs
+                </p>
+                <div className="grid gap-4 mt-4 justify-items-center sm:grid-cols-2 sm:justify-items-start sm:gap-x-8">
+                  {programs.map((program, index) => (
+                    <Link
+                      href={`/programs/${program.slug}`}
+                      key={`mobile-dropdown-${program.data.name}`}
+                      className={clsx(index % 2 == 1 && 'sm:justify-self-end')}
+                    >
+                      <div className="group relative p-0.5">
+                        <span className="relative z-10 text-xl font-medium duration-300 ease-in-out text-purple-50 group-hover:text-white">
+                          {program.data.name}
+                        </span>
+                        <span className="absolute -left-1 -right-1 bottom-0 h-1.5 origin-bottom scale-x-0 transform rounded-lg bg-yellow-400 duration-300 ease-in-out group-hover:scale-x-100" />
+                      </div>
+                    </Link>
+                  ))}
                 </div>
               </div>
-            </Popover.Panel>
-          </Transition>
+            </div>
+          </PopoverPanel>
         </Popover>
       </div>
     )
@@ -155,86 +122,68 @@ export function Navbar({ programs }) {
   return (
     <div className="px-4 sm:px-6">
       <nav className="mx-auto flex max-w-(--breakpoint-xl) items-center pt-5">
-        <div className="flex w-full items-center justify-between">
+        <div className="flex items-center justify-between w-full">
           {/* Main navigation menu for large screens */}
-          <div className="hidden items-center justify-between md:space-x-6 lg:flex lg:space-x-10">
+          <div className="items-center justify-between hidden md:space-x-6 lg:flex lg:space-x-10">
             {navigation.map(link => (
               <Fragment key={`desktop-link-${link.label}`}>
                 {link.label == 'Programs' ? (
                   <Menu as="div" className="relative">
-                    {({ open }) => (
-                      <>
-                        <Menu.Button>
-                          <div className="group cursor-pointer relative p-0.5">
-                            <span
-                              className={clsx(
-                                'relative z-10 flex items-center text-lg font-medium duration-300 ease-in-out group-hover:text-purple-600',
-                                open ? 'text-purple-600' : 'text-purple-700'
-                              )}
-                            >
-                              Programs
-                              {/* Heroicon name: solid/chevron-down */}
-                              {/* Toggle class 'rotate-180' on dropdown open and close */}
-                              <Icon
-                                icon="chevronDown"
-                                className={clsx(
-                                  'h-4.5 ml-1.5 w-4.5 transform duration-300 ease-in-out',
-                                  open && 'rotate-180'
-                                )}
-                                stroke={2}
-                              />
-                            </span>
-                            <span className="absolute -left-1 -right-1 bottom-0 h-1.5 origin-bottom scale-x-0 transform rounded-lg bg-yellow-400 duration-300 ease-in-out group-hover:scale-x-100" />
-                          </div>
-                        </Menu.Button>
+                    <MenuButton className="outline-none cursor-pointer group focus:outline-none">
+                      <div className="group relative p-0.5">
+                        <span className="relative z-10 flex items-center text-lg font-medium text-purple-700 duration-300 ease-in-out group-hover:text-purple-600 group-data-[open]:text-purple-600">
+                          Programs
+                          {/* Heroicon name: solid/chevron-down */}
+                          {/* Toggle class 'rotate-180' on dropdown open and close */}
+                          <Icon
+                            icon="chevronDown"
+                            className="h-4.5 ml-1.5 w-4.5 transform duration-300 ease-in-out group-data-[open]:rotate-180"
+                            stroke={2}
+                          />
+                        </span>
+                        <span className="absolute -left-1 -right-1 bottom-0 h-1.5 origin-bottom scale-x-0 transform rounded-lg bg-yellow-400 duration-300 ease-in-out group-hover:scale-x-100" />
+                      </div>
+                    </MenuButton>
 
-                        <Transition
-                          as={Fragment}
-                          enter="transition ease-out duration-300"
-                          enterFrom="transform opacity-0 scale-95"
-                          enterTo="transform opacity-100 scale-100"
-                          leave="transition ease-in duration-200"
-                          leaveFrom="transform opacity-100 scale-100"
-                          leaveTo="transform opacity-0 scale-95"
+                    <MenuItems
+                      transition
+                      modal={false}
+                      className="absolute left-1/2 z-20 mt-3 w-screen max-w-xs -translate-x-1/2 rounded-2xl border border-gray-50 bg-white p-4 shadow-lg outline-none focus:outline-none data-[closed]:scale-95 data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in"
+                    >
+                      {programs.map((program, index) => (
+                        <MenuItem
+                          key={`desktop-dropdown-link-${program.data.name}`}
+                          as="div"
                         >
-                          <Menu.Items className="absolute left-1/2 z-20 mt-3 w-screen max-w-xs -translate-x-1/2 rounded-2xl border border-gray-50 bg-white p-4 shadow-lg">
-                            {programs.map((program, index) => (
-                              <Menu.Item
-                                key={`desktop-dropdown-link-${program.data.name}`}
-                                as="div"
-                              >
-                                {({ close }) => (
-                                  <>
-                                    <Link
-                                      href={`/programs/${program.slug}`}
-                                      className={clsx(
-                                        'group block w-full rounded-xl py-4 sm:p-5',
-                                        pathname === `/programs/${program.slug}`
-                                          ? 'bg-purple-25'
-                                          : 'transition duration-200 ease-in-out hover:bg-purple-25/60'
-                                      )}
-                                      onClick={close}
-                                    >
-                                      <h5 className="text-lg font-semibold text-purple-600">
-                                        {program.data.name}
-                                      </h5>
-                                      <p className="mt-1 text-sm text-purple-800/90">
-                                        {program.data.dropdownDescription}
-                                      </p>
-                                    </Link>
-                                    {index != programs.length - 1 && (
-                                      <>
-                                        <hr className="my-1 border-purple-200/30 sm:my-2" />
-                                      </>
-                                    )}
-                                  </>
+                          {({ close }) => (
+                            <>
+                              <Link
+                                href={`/programs/${program.slug}`}
+                                className={clsx(
+                                  'group block w-full rounded-xl py-4 sm:p-5',
+                                  pathname === `/programs/${program.slug}`
+                                    ? 'bg-purple-25'
+                                    : 'transition duration-200 ease-in-out hover:bg-purple-25/60'
                                 )}
-                              </Menu.Item>
-                            ))}
-                          </Menu.Items>
-                        </Transition>
-                      </>
-                    )}
+                                onClick={close}
+                              >
+                                <h5 className="text-lg font-semibold text-purple-600">
+                                  {program.data.name}
+                                </h5>
+                                <p className="mt-1 text-sm text-purple-800 opacity-90">
+                                  {program.data.dropdownDescription}
+                                </p>
+                              </Link>
+                              {index != programs.length - 1 && (
+                                <>
+                                  <hr className="my-1 border-purple-200/30 sm:my-2" />
+                                </>
+                              )}
+                            </>
+                          )}
+                        </MenuItem>
+                      ))}
+                    </MenuItems>
                   </Menu>
                 ) : (
                   <Link href={link.href}>


### PR DESCRIPTION
### Changes
1. Bumped @headlessui/react to v2.2.
2. Set modal={false} on the `<MenuItems>` component in `Navbar` to prevent the scroll-lock style from being applied to `<html>`.
3. Refactored related components (navbar, FAQ) to align with the latest Headless UI API.

### Additional Context
In Headless UI 2.x, `<Menu>` defaults to a “modal” mode, adding scroll locking and focus trapping. For dropdown menus, this caused an unwanted `overflow: hidden` on `<html>`, preventing scrolling on the page or within the dropdown. Disabling modal mode fixes the scroll issue. This keeps the code up to date with the latest Headless UI best practices.

The scroll locking is useful for true modals but not ideal for standard dropdown menus. By setting `modal={false}`, we preserve normal page scrolling and still benefit from Headless UI’s other features.